### PR TITLE
Release 1.1.0.

### DIFF
--- a/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
+++ b/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
@@ -1,4 +1,4 @@
-// Fermata.RadixConversion Version 1.0.0
+// Fermata.RadixConversion Version 1.1.0
 // https://github.com/taidalog/Fermata.RadixConversion
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
+++ b/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
@@ -7,7 +7,6 @@ module Fermata.RadixConversion.Tests
 
 open System
 open Xunit
-open Fermata
 open Fermata.RadixConversion
 
 let testDecToBeError (expected: Dec) (actual: Dec) : unit =
@@ -72,12 +71,36 @@ let testResultToBeError (expected: Result<'T, exn>) (actual: Result<'T, exn>) : 
 
 [<Fact>]
 let ``Dec.validate 1`` () =
+    let actual = "2" |> Dec.validate
+    let expected = Dec.Valid 2
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Dec.validate 2`` () =
+    let actual = "0" |> Dec.validate
+    let expected = Dec.Valid 0
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Dec.validate 3`` () =
+    let actual = "0000" |> Dec.validate
+    let expected = Dec.Valid 0
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Dec.validate 4`` () =
     let actual = "42" |> Dec.validate
     let expected = Dec.Valid 42
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``Dec.validate 2`` () =
+let ``Dec.validate 5`` () =
+    let actual = "0042" |> Dec.validate
+    let expected = Dec.Valid 42
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Dec.validate 6`` () =
     let actual = "FF" |> Dec.validate
 
     let expected =
@@ -86,7 +109,7 @@ let ``Dec.validate 2`` () =
     testDecToBeError expected actual
 
 [<Fact>]
-let ``Dec.validate 3`` () =
+let ``Dec.validate 7`` () =
     let actual = "2147483648" |> Dec.validate
 
     let expected =
@@ -126,12 +149,36 @@ let ``Dec.toHex 2`` () =
 
 [<Fact>]
 let ``Bin.validate 1`` () =
+    let actual = "1" |> Bin.validate
+    let expected = Bin.Valid "1"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Bin.validate 2`` () =
+    let actual = "0" |> Bin.validate
+    let expected = Bin.Valid "0"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Bin.validate 3`` () =
+    let actual = "0000" |> Bin.validate
+    let expected = Bin.Valid "0"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Bin.validate 4`` () =
     let actual = "101010" |> Bin.validate
     let expected = Bin.Valid "101010"
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``Bin.validate 2`` () =
+let ``Bin.validate 5`` () =
+    let actual = Bin.validate "0000101010"
+    let expected = Bin.Valid "101010"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Bin.validate 6`` () =
     let actual = "FF" |> Bin.validate
 
     let expected =
@@ -140,7 +187,7 @@ let ``Bin.validate 2`` () =
     testBinToBeError expected actual
 
 [<Fact>]
-let ``Bin.validate 3`` () =
+let ``Bin.validate 7`` () =
     let actual = "100000000000000000000000000000000" |> Bin.validate
 
     let expected =
@@ -165,12 +212,36 @@ let ``Bin.toDec 2`` () =
 
 [<Fact>]
 let ``Hex.validate 1`` () =
+    let actual = "a" |> Hex.validate
+    let expected = Hex.Valid "a"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Hex.validate 2`` () =
+    let actual = "0" |> Hex.validate
+    let expected = Hex.Valid "0"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Hex.validate 3`` () =
+    let actual = "0000" |> Hex.validate
+    let expected = Hex.Valid "0"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Hex.validate 4`` () =
     let actual = "FF" |> Hex.validate
     let expected = Hex.Valid "FF"
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``Hex.validate 2`` () =
+let ``Hex.validate 5`` () =
+    let actual = Hex.validate "00FF"
+    let expected = Hex.Valid "FF"
+    Assert.Equal(expected, actual)
+
+[<Fact>]
+let ``Hex.validate 6`` () =
     let actual = "XX" |> Hex.validate
 
     let expected =
@@ -179,7 +250,7 @@ let ``Hex.validate 2`` () =
     testHexToBeError expected actual
 
 [<Fact>]
-let ``Hex.validate 3`` () =
+let ``Hex.validate 7`` () =
     let actual = "FFFFFFFFF" |> Hex.validate
 
     let expected =

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fs
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fs
@@ -1,4 +1,4 @@
-﻿// Fermata.RadixConversion Version 1.0.0
+﻿// Fermata.RadixConversion Version 1.1.0
 // https://github.com/taidalog/Fermata.RadixConversion
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fs
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fs
@@ -6,6 +6,7 @@
 namespace Fermata.RadixConversion
 
 open System
+open System.Text.RegularExpressions
 open Fermata
 open Fermata.Validators
 
@@ -49,10 +50,18 @@ module Dec =
 [<RequireQualifiedAccess>]
 module Bin =
     let validate (input: string) : Bin =
+        let removeLeadingZeros (input: string) : Result<string, exn> =
+            try
+                let m = Regex.Match(input, "^0*([01]+)$")
+                Ok(m.Groups[1].Value)
+            with (e: exn) ->
+                Error e
+
         Ok input
         |> Result.bind validateNotEmptyString
         |> Result.bind (validateFormat "^[01]+$")
         |> Result.bind (validateMaxLength String.length 32)
+        |> Result.bind removeLeadingZeros
         |> function
             | Ok x -> Bin.Valid x
             | Error e -> Bin.Invalid e
@@ -66,10 +75,18 @@ module Bin =
 [<RequireQualifiedAccess>]
 module Hex =
     let validate (input: string) : Hex =
+        let removeLeadingZeros (input: string) : Result<string, exn> =
+            try
+                let m = Regex.Match(input, "^0*([0-9A-Fa-f]+)$")
+                Ok(m.Groups[1].Value)
+            with (e: exn) ->
+                Error e
+
         Ok input
         |> Result.bind validateNotEmptyString
         |> Result.bind (validateFormat "^[0-9A-Fa-f]+$")
         |> Result.bind (validateMaxLength String.length 8)
+        |> Result.bind removeLeadingZeros
         |> function
             | Ok x -> Hex.Valid x
             | Error e -> Hex.Invalid e

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fsi
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fsi
@@ -1,4 +1,4 @@
-// Fermata.RadixConversion Version 1.0.0
+// Fermata.RadixConversion Version 1.1.0
 // https://github.com/taidalog/Fermata.RadixConversion
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fsi
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fsi
@@ -32,19 +32,47 @@ module Dec =
     ///
     /// <example id="Dec.validate-1">
     /// <code lang="fsharp">
+    /// "2" |> Dec.validate
+    /// </code>
+    /// Evaluates to <c>Dec.Valid 2</c>
+    /// </example>
+    ///
+    /// <example id="Dec.validate-2">
+    /// <code lang="fsharp">
+    /// "0" |> Dec.validate
+    /// </code>
+    /// Evaluates to <c>Dec.Valid 0</c>
+    /// </example>
+    ///
+    /// <example id="Dec.validate-3">
+    /// <code lang="fsharp">
+    /// "0000" |> Dec.validate
+    /// </code>
+    /// Evaluates to <c>Dec.Valid 0</c>
+    /// </example>
+    ///
+    /// <example id="Dec.validate-4">
+    /// <code lang="fsharp">
     /// "42" |> Dec.validate
     /// </code>
     /// Evaluates to <c>Dec.Valid 42</c>
     /// </example>
     ///
-    /// <example id="Dec.validate-2">
+    /// <example id="Dec.validate-5">
+    /// <code lang="fsharp">
+    /// "0042" |> Dec.validate
+    /// </code>
+    /// Evaluates to <c>Dec.Valid 42</c>
+    /// </example>
+    ///
+    /// <example id="Dec.validate-6">
     /// <code lang="fsharp">
     /// "FF" |> Dec.validate
     /// </code>
     /// Evaluates to <c>Dec.Invalid(FormatException "The input string 'FF' was not in a correct format.")</c>
     /// </example>
     ///
-    /// <example id="Dec.validate-3">
+    /// <example id="Dec.validate-7">
     /// <code lang="fsharp">
     /// "2147483648" |> Dec.validate
     /// </code>
@@ -105,19 +133,47 @@ module Bin =
     ///
     /// <example id="Bin.validate-1">
     /// <code lang="fsharp">
+    /// "1" |> Bin.validate
+    /// </code>
+    /// Evaluates to <c>Bin.Valid "1"</c>
+    /// </example>
+    ///
+    /// <example id="Bin.validate-2">
+    /// <code lang="fsharp">
+    /// "0" |> Bin.validate
+    /// </code>
+    /// Evaluates to <c>Bin.Valid "0"</c>
+    /// </example>
+    ///
+    /// <example id="Bin.validate-3">
+    /// <code lang="fsharp">
+    /// "0000" |> Bin.validate
+    /// </code>
+    /// Evaluates to <c>Bin.Valid "0"</c>
+    /// </example>
+    ///
+    /// <example id="Bin.validate-4">
+    /// <code lang="fsharp">
     /// "101010" |> Bin.validate
     /// </code>
     /// Evaluates to <c>Bin.Valid "101010"</c>
     /// </example>
     ///
-    /// <example id="Bin.validate-2">
+    /// <example id="Bin.validate-5">
+    /// <code lang="fsharp">
+    /// "0000101010" |> Bin.validate
+    /// </code>
+    /// Evaluates to <c>Bin.Valid "101010"</c>
+    /// </example>
+    ///
+    /// <example id="Bin.validate-6">
     /// <code lang="fsharp">
     /// "FF" |> Bin.validate
     /// </code>
     /// Evaluates to <c>Bin.Invalid(FormatException "The input string 'FF' was not in a correct format.")</c>
     /// </example>
     ///
-    /// <example id="Bin.validate-3">
+    /// <example id="Bin.validate-7">
     /// <code lang="fsharp">
     /// "100000000000000000000000000000000" |> Bin.validate
     /// </code>
@@ -157,19 +213,47 @@ module Hex =
     ///
     /// <example id="Hex.validate-1">
     /// <code lang="fsharp">
-    /// "FF" |> Hex.validate
+    /// "a" |> Hex.validate
+    /// </code>
+    /// Evaluates to <c>Hex.Valid "a"</c>
+    /// </example>
+    ///
+    /// <example id="Hex.validate-2">
+    /// <code lang="fsharp">
+    /// "0" |> Hex.validate
+    /// </code>
+    /// Evaluates to <c>Hex.Valid "0"</c>
+    /// </example>
+    ///
+    /// <example id="Hex.validate-3">
+    /// <code lang="fsharp">
+    /// "0000" |> Hex.validate
+    /// </code>
+    /// Evaluates to <c>Hex.Valid "0"</c>
+    /// </example>
+    ///
+    /// <example id="Hex.validate-4">
+    /// <code lang="fsharp">
+    /// Hex.validate "FF"
     /// </code>
     /// Evaluates to <c>Hex.Valid "FF"</c>
     /// </example>
     ///
-    /// <example id="Hex.validate-2">
+    /// <example id="Hex.validate-5">
+    /// <code lang="fsharp">
+    /// Hex.validate "00FF"
+    /// </code>
+    /// Evaluates to <c>Hex.Valid "FF"</c>
+    /// </example>
+    ///
+    /// <example id="Hex.validate-6">
     /// <code lang="fsharp">
     /// "XX" |> Hex.validate
     /// </code>
     /// Evaluates to <c>Hex.Invalid(FormatException "The input string 'XX' was not in a correct format.")</c>
     /// </example>
     ///
-    /// <example id="Hex.validate-3">
+    /// <example id="Hex.validate-7">
     /// <code lang="fsharp">
     /// "FFFFFFFFF" |> Hex.validate
     /// </code>

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fsproj
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Fermata.RadixConversion</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>taidalog</Authors>
     <Company />
     <Description>F# library for operations related to radix conversion. Compatible with Fable.</Description>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 F# library for operations related to radix conversion. Compatible with Fable.
 
-Version 1.0.0
+Version 1.1.0
 
 ## Features
 
@@ -34,13 +34,13 @@ For more information, see the signature file (`.fsi`).
 .NET CLI,
 
 ```
-dotnet add package Fermata.RadixConversion --version 1.0.0
+dotnet add package Fermata.RadixConversion --version 1.1.0
 ```
 
 F# Intaractive,
 
 ```
-#r "nuget: Fermata.RadixConversion, 1.0.0"
+#r "nuget: Fermata.RadixConversion, 1.1.0"
 ```
 
 For more information, please see [Fermata on NuGet Gallery](https://www.nuget.org/packages/Fermata.RadixConversion).

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ For more information, please see [Fermata on NuGet Gallery](https://www.nuget.or
 
 ## Breaking Changes
 
+### 1.1.0
+
+- `Bin.validate` and `Hex.validate` return the input binary number representation or hexadecimal representation **without** leading zeros, while they used to return the input value **with** leading zeros.
+
 ### 1.0.0
 
 - Functions in the module contains the built-in exceptions on failure, while they used to contain `Fermata.Exceptions`.


### PR DESCRIPTION
## Summary

- Removed leading zeros from the result from `Bin.validate` and `Hex.validate`.

## Breaking Changes

- `Bin.validate` and `Hex.validate` return the input binary number representation or hexadecimal representation **without** leading zeros, while they used to return the input value **with** leading zeros.