### PR TITLE
Release 1.2.0.

### DIFF
--- a/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
+++ b/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
@@ -231,13 +231,13 @@ let ``Hex.validate 3`` () =
 [<Fact>]
 let ``Hex.validate 4`` () =
     let actual = "FF" |> Hex.validate
-    let expected = Hex.Valid "FF"
+    let expected = Hex.Valid "ff"
     Assert.Equal(expected, actual)
 
 [<Fact>]
 let ``Hex.validate 5`` () =
     let actual = Hex.validate "00FF"
-    let expected = Hex.Valid "FF"
+    let expected = Hex.Valid "ff"
     Assert.Equal(expected, actual)
 
 [<Fact>]
@@ -260,12 +260,17 @@ let ``Hex.validate 7`` () =
 
 [<Fact>]
 let ``Hex.toDec 1`` () =
+    let actual = "A1" |> Hex.validate |> Hex.toDec
+    let expected = Dec.Valid 161
+    Assert.Equal(expected, actual)
+[<Fact>]
+let ``Hex.toDec 2`` () =
     let actual = "ff" |> Hex.validate |> Hex.toDec
     let expected = Dec.Valid 255
     Assert.Equal(expected, actual)
 
 [<Fact>]
-let ``Hex.toDec 2`` () =
+let ``Hex.toDec 3`` () =
     let actual = "XX" |> Hex.validate |> Hex.toDec
 
     let expected =

--- a/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
+++ b/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fs
@@ -1,4 +1,4 @@
-// Fermata.RadixConversion Version 1.1.0
+// Fermata.RadixConversion Version 1.2.0
 // https://github.com/taidalog/Fermata.RadixConversion
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fsproj
+++ b/Fermata.RadixConversion.Tests/Fermata.RadixConversion.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fs
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fs
@@ -1,4 +1,4 @@
-﻿// Fermata.RadixConversion Version 1.1.0
+﻿// Fermata.RadixConversion Version 1.2.0
 // https://github.com/taidalog/Fermata.RadixConversion
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fs
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fs
@@ -44,7 +44,7 @@ module Dec =
     let toHex (dec: Dec) : Hex =
         dec
         |> function
-            | Dec.Valid x -> System.Convert.ToString(x, 16) |> Hex.Valid
+            | Dec.Valid x -> System.Convert.ToString(x, 16) |> fun (x: string) -> x.ToLower() |> Hex.Valid
             | Dec.Invalid e -> Hex.Invalid e
 
 [<RequireQualifiedAccess>]
@@ -87,6 +87,7 @@ module Hex =
         |> Result.bind (validateFormat "^[0-9A-Fa-f]+$")
         |> Result.bind (validateMaxLength String.length 8)
         |> Result.bind removeLeadingZeros
+        |> Result.map (fun (x: string) -> x.ToLower())
         |> function
             | Ok x -> Hex.Valid x
             | Error e -> Hex.Invalid e

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fsi
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fsi
@@ -1,4 +1,4 @@
-// Fermata.RadixConversion Version 1.1.0
+// Fermata.RadixConversion Version 1.2.0
 // https://github.com/taidalog/Fermata.RadixConversion
 // Copyright (c) 2024 taidalog
 // This software is licensed under the MIT License.

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fsi
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fsi
@@ -236,14 +236,14 @@ module Hex =
     /// <code lang="fsharp">
     /// Hex.validate "FF"
     /// </code>
-    /// Evaluates to <c>Hex.Valid "FF"</c>
+    /// Evaluates to <c>Hex.Valid "ff"</c>
     /// </example>
     ///
     /// <example id="Hex.validate-5">
     /// <code lang="fsharp">
     /// Hex.validate "00FF"
     /// </code>
-    /// Evaluates to <c>Hex.Valid "FF"</c>
+    /// Evaluates to <c>Hex.Valid "ff"</c>
     /// </example>
     ///
     /// <example id="Hex.validate-6">
@@ -268,12 +268,19 @@ module Hex =
     ///
     /// <example id="Hex.toDec-1">
     /// <code lang="fsharp">
+    /// "A1" |> Hex.validate |> Hex.toDec
+    /// </code>
+    /// Evaluates to <c>Dec.Valid 161</c>
+    /// </example>
+    ///
+    /// <example id="Hex.toDec-2">
+    /// <code lang="fsharp">
     /// "ff" |> Hex.validate |> Hex.toDec
     /// </code>
     /// Evaluates to <c>Dec.Valid 255</c>
     /// </example>
     ///
-    /// <example id="Hex.toDec-2">
+    /// <example id="Hex.toDec-3">
     /// <code lang="fsharp">
     /// "XX" |> Hex.validate |> Hex.toDec
     /// </code>

--- a/Fermata.RadixConversion/Fermata.RadixConversion.fsproj
+++ b/Fermata.RadixConversion/Fermata.RadixConversion.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Fermata.RadixConversion</PackageId>
     <Version>1.1.0</Version>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 F# library for operations related to radix conversion. Compatible with Fable.
 
-Version 1.1.0
+Version 1.2.0
 
 ## Features
 
@@ -34,7 +34,7 @@ For more information, see the signature file (`.fsi`).
 .NET CLI,
 
 ```
-dotnet add package Fermata.RadixConversion --version 1.1.0
+dotnet add package Fermata.RadixConversion --Version 1.2.0
 ```
 
 F# Intaractive,

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Version 1.2.0
 ## Target Frameworks
 
 - .NET Standard 2.0
-- .NET 6
 - .NET 7
 - .NET 8
+- .NET 9
 
 ## Modules
 
@@ -40,7 +40,7 @@ dotnet add package Fermata.RadixConversion --Version 1.2.0
 F# Intaractive,
 
 ```
-#r "nuget: Fermata.RadixConversion, 1.1.0"
+#r "nuget: Fermata.RadixConversion, 1.2.0"
 ```
 
 For more information, please see [Fermata on NuGet Gallery](https://www.nuget.org/packages/Fermata.RadixConversion).
@@ -58,6 +58,11 @@ For more information, please see [Fermata on NuGet Gallery](https://www.nuget.or
 [Releases on GitHub](https://github.com/taidalog/Fermata.RadixConversion/releases)
 
 ## Breaking Changes
+
+### 1.2.0
+
+- `Hex.validate` returns the input hexadecimal representation in **lower case**, while it used to return the input value in **upper case or in lower case** according to the input.
+- .NET 6.0 is no longer supported.
 
 ### 1.1.0
 


### PR DESCRIPTION
## Summary

- Change `Hex` to always hold a hex value in lower case.
- Add `dotnet 9` to target frameworks and remove `dotnet 6`. Close #15.

## Breaking Changes

- `Hex.validate` returns the input hexadecimal representation in **lower case**, while it used to return the input value in **upper case or in lower case** according to the input.
- .NET 6.0 is no longer supported.